### PR TITLE
Add support for Google Play Music + all media key actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 browser-media-keys
 ==================
 
-Lets you control Youtube, Pandora, Bandcamp and TidalHiFi website media players using the media keys on your keyboard. If you're not using Windows then this plugin requires that a browser window is active.
+Lets you control Youtube, Pandora, Bandcamp, TidalHiFi and Google Play Music
+website media players using the media keys on your keyboard. If you're not
+using Windows then this plugin requires that a browser window is active.

--- a/data/orchestrator.js
+++ b/data/orchestrator.js
@@ -1,43 +1,68 @@
 /**
  * MediaKeys namespace.
+ * 
+ * Supports backwards compatibility with older Gecko key values.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
  */
 MediaKeys.Init = function(undefined)
 {
-	self.port.on("MediaPlayPause", function(){
+	self.port.on("MediaPlay", function() {
 		var playButton = MediaKeys.GetSingleElementByXpath(MediaKeys.playButton);
-		if (playButton != null)
-		{
-			playButton.click();
-		}
-		else
-		{
-			var pauseButton = MediaKeys.GetSingleElementByXpath(MediaKeys.pauseButton)
-			if (pauseButton != null) pauseButton.click();
-			else return;
-		}
-		self.port.emit("MediaPlayPause");
+		if (playButton == null) return;
+		playButton.click();
+		self.port.emit("MediaPlay");
 	});
 
-	self.port.on("MediaNextTrack", function(){
-		var skipButton = MediaKeys.GetSingleElementByXpath(MediaKeys.skipButton);
-		if (skipButton == null) return;
-		skipButton.click();
-		self.port.emit("MediaNextTrack");
-	});
+	var playPause = function(keyId){
+		return function(){
+			var playButton = MediaKeys.GetSingleElementByXpath(MediaKeys.playButton);
+			if (playButton != null)
+			{
+				playButton.click();
+			}
+			else
+			{
+				var pauseButton = MediaKeys.GetSingleElementByXpath(MediaKeys.pauseButton)
+				if (pauseButton != null) pauseButton.click();
+				else return;
+			}
+			self.port.emit(keyId);
+		};
+	};
+	self.port.on("MediaPlayPause", playPause("MediaPlayPause"));
 
-	self.port.on("MediaPreviousTrack", function(){
-		var previousButton = MediaKeys.GetSingleElementByXpath(MediaKeys.previousButton);
-		if (previousButton == null) return;
-		previousButton.click();
-		self.port.emit("MediaPreviousTrack");
-	});
+	var nextTrack = function(keyId) {
+		return function(){
+			var skipButton = MediaKeys.GetSingleElementByXpath(MediaKeys.skipButton);
+			if (skipButton == null) return;
+			skipButton.click();
+			self.port.emit(keyId);
+		};
+	};
+	self.port.on("MediaNextTrack", nextTrack("MediaNextTrack"));
+	self.port.on("MediaTrackNext", nextTrack("MediaTrackNext")); //Gecko 37+
 
-	self.port.on("MediaStop", function(){
-		var pauseButton = MediaKeys.GetSingleElementByXpath(MediaKeys.pauseButton);
-		if (pauseButton == null) return;
-		pauseButton.click();
-		self.port.emit("MediaStop");
-	});
+	var previousTrack = function(keyId) {
+		return function(){
+			var previousButton = MediaKeys.GetSingleElementByXpath(MediaKeys.previousButton);
+			if (previousButton == null) return;
+			previousButton.click();
+			self.port.emit(keyId);
+		};
+	};
+	self.port.on("MediaPreviousTrack", previousTrack("MediaNextTrack"));
+	self.port.on("MediaTrackPrevious", previousTrack("MediaTrackPrevious")); //Gecko 37+
+
+	var pause = function(keyId) {
+		return function(){
+			var pauseButton = MediaKeys.GetSingleElementByXpath(MediaKeys.pauseButton);
+			if (pauseButton == null) return;
+			pauseButton.click();
+			self.port.emit("MediaStop");
+		};
+	};
+	self.port.on("MediaPause", pause("MediaPause"));
+	self.port.on("MediaStop", pause("MediaStop"));
 }
 
 MediaKeys.Init();

--- a/data/play.google.com-view.js
+++ b/data/play.google.com-view.js
@@ -1,0 +1,9 @@
+/**
+ * MediaKeys namespace.
+ */
+if (typeof MediaKeys == "undefined") var MediaKeys = {};
+
+MediaKeys.playButton = "//sj-icon-button[@data-id='play-pause']";
+MediaKeys.pauseButton = "//sj-icon-button[@data-id='play-pause']";
+MediaKeys.skipButton = "//sj-icon-button[@data-id='forward']";
+MediaKeys.previousButton = "//sj-icon-button[@data-id='rewind']";

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var supportedPageDomains = ["pandora.com", "tidalhifi.com", "youtube.com", "bandcamp.com"];
+var supportedPageDomains = ["pandora.com", "tidalhifi.com", "youtube.com", "bandcamp.com", "play.google.com"];
 var hotkeyManager;
 
 //attach content scripts to appropriate websites

--- a/lib/firefoxHotkeys.js
+++ b/lib/firefoxHotkeys.js
@@ -57,9 +57,13 @@ var KeyEventHandler = function(event) {
 	{
 		// Handle the event with KeyboardEvent.key and set handled true.
 		switch (event.key){
+			case "MediaPlay":
 			case "MediaPlayPause":
+			case "MediaPause":
 			case "MediaPreviousTrack":
 			case "MediaNextTrack":
+			case "MediaTrackNext":
+			case "MediaTrackPrevious":
 			case "MediaStop":
 				EmitEvent({data: event.key});
 				break;

--- a/lib/hotkeyManager.js
+++ b/lib/hotkeyManager.js
@@ -19,7 +19,7 @@ var RegisterHotkeys = function()
 			break;
 		default:
 			console.log("Global hotkeys not supported for " + system.platform + ". Falling back to browser hotkeys");
-			aHotkeyWorker = require("firefoxHotkeys");
+			aHotkeyWorker = require("./firefoxHotkeys");
 			aHotkeyWorker.addEventListener(EmitEventToActivePageWorker);
 	}
 			

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browsermediakeys",
   "title": "Media Keys",
-  "description": "Lets you control Youtube, Pandora, Bandcamp and TidalHiFi website media players using the media keys on your keyboard.",
+  "description": "Lets you control Youtube, Pandora, Bandcamp, TidalHiFi, and Google Play Music website media players using the media keys on your keyboard.",
   "author": "Carlin Scott",
   "id": "jid1-4GP7z3tkUd3Tzg@jetpack",
   "license": "MPL 2.0",


### PR DESCRIPTION
Awesome addon, thanks!

This PR adds support for Google Play Music.  

In doing so, I noticed that the key values being emitted by my Firefox 39.0a2 install on Ubuntu 15.04 (Linux) weren't being picked up -- some key ids have even been changed in later versions of Gecko; so I've added support for those missing keys from https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

Finally, my FF was initially erroring due to the ``require("firefoxHotkeys")`` line in hotkeyManager.js; so I adjusted this to be a relative path to the given file and this resolved the error.  

This is my first attempt at hacking on a FF addon, so if any of this is wrong, let me know.  Otherwise, working on my install of FF on Ubuntu.