### PR TITLE
Fix Google Play Music changes in HTML structure

### DIFF
--- a/data/play.google.com-view.js
+++ b/data/play.google.com-view.js
@@ -3,7 +3,7 @@
  */
 if (typeof MediaKeys == "undefined") var MediaKeys = {};
 
-MediaKeys.playButton = "//sj-icon-button[@data-id='play-pause']";
-MediaKeys.pauseButton = "//sj-icon-button[@data-id='play-pause']";
-MediaKeys.skipButton = "//sj-icon-button[@data-id='forward']";
-MediaKeys.previousButton = "//sj-icon-button[@data-id='rewind']";
+MediaKeys.playButton = "//*[@data-id='play-pause'][1]";
+MediaKeys.pauseButton = "//*[@data-id='play-pause'][1]";
+MediaKeys.skipButton = "//*[@data-id='forward'][1]";
+MediaKeys.previousButton = "//*[@data-id='rewind'][1]";


### PR DESCRIPTION
Play music changed today from `sj-icon-button` elements to `paper-icon-button`.  This handles any *further* element changes.  We're still brittle against a data-id attribute change, but in this case, it's the most (only?) consistent thing short of using some logic to go hunting for the buttons.

Tested and working again on today's changes and in Firefox 43a02 on Ubuntu 15.10.