### PR TITLE
Add (better) Madsonic Support

### DIFF
--- a/data/madsonic-view.js
+++ b/data/madsonic-view.js
@@ -1,0 +1,16 @@
+/**
+ * MediaKeys namespace.
+ */
+/**
+ * MediaKeys namespace.
+ */
+if (typeof MediaKeys == "undefined") var MediaKeys = {};
+
+console.log("subsonic loaded");
+
+MediaKeys.basePlayer = "//iframe[@id='playQueue']";
+
+MediaKeys.playButton = "//span[contains(@id, 'startButton') and not(contains(@style,'display: none'))]";
+MediaKeys.pauseButton = "//span[contains(@id, 'stopButton') and not(contains(@style,'display: none'))]";
+MediaKeys.skipButton = "//span[@id='nextButton']";
+MediaKeys.previousButton = "//span[@id='previousButton']";

--- a/data/pageMods.json
+++ b/data/pageMods.json
@@ -73,6 +73,10 @@
     "include": "@SubsonicDomains"
   },
   {
+    "name": "madsonic",
+    "include": "@MadsonicDomains"
+  },
+  {
     "name": "music.amazon",
     "include": ["*.music.amazon.com", "*.music.amazon.de"]
   },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
       "description": "Domains like '*.demo.subsonic.org' (separated by simple space)",
       "type": "string",
       "value": "*.demo.subsonic.org"
+    },
+    {
+      "name": "MadsonicDomains",
+      "title": "Madsonic Domains",
+      "description": "Domains like '*.demo.madsonic.org' (separated by simple space)",
+      "type": "string",
+      "value": "*.demo.madsonic.org"
     }
   ],
   "permissions": {


### PR DESCRIPTION
since new Subsonic versions aren't OSS anymore there should be support for a good alternative
Media Keys differ only slightly: Subsonic uses <i> tags for forward and backward whereas madsonic uses <span> tags